### PR TITLE
feat(footer): support link

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -21,6 +21,11 @@ const Footer = () => {
                   Privacy
                 </div>
               </Link>
+              <Link to="https://github.com/elixir-cloud-aai/krini/issues" target='_blank'>
+                <div className="hover:underline hover:text-gray-300 cursor-pointer">
+                  Support
+                </div>
+              </Link>
             </div>
             <div>&#169; 2022 Krini. All rights reserved.</div>
           </div>


### PR DESCRIPTION
**Details**

closes #29 

- Through this commit I added a "Support" link in the footer that redirects the user to the Github Issue tracker page.
- Used the react-router-dom based Link component as used in the exisiting code.
- Added target="_blank" attribute to open link in a new tab.
- The new div for "Support" contains the same tailwind classname as used in the already exisitng "About","Privacy" links.

Screenshot for reference :
![image](https://github.com/elixir-cloud-aai/krini/assets/75206987/441143cb-c474-4e24-95f9-91c441af45a5)
