### PR TITLE
Update LSAAI login

### DIFF
--- a/src/components/login/index.tsx
+++ b/src/components/login/index.tsx
@@ -10,7 +10,7 @@ const Login: FC<LoginProps> = ({ isLoggedIn }) => {
     if (isLoggedIn === LoginStatus.LOGGED_IN) {
       return navigate('/');
     } else if (isLoggedIn === LoginStatus.NOT_LOGGED_IN) {
-      window.location.href = `https://login.elixir-czech.org/oidc/authorize?response_type=token id_token&scope=openid profile email eduperson_entitlement ga4gh_passport_v1&client_id=5fc66010-a596-48e4-8c09-89a767ef136c&state=StAtE&redirect_uri=${HOST_URI}`;
+      window.location.href = `https://login.aai.lifescience-ri.eu/oidc/authorize?response_type=token id_token&scope=openid profile email eduperson_entitlement ga4gh_passport_v1&client_id=5fc66010-a596-48e4-8c09-89a767ef136c&state=StAtE&redirect_uri=${HOST_URI}`;
     }
   }, [isLoggedIn, navigate]);
 

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -36,7 +36,7 @@ const Navbar: FC<NavbarProps> = ({
   const handleLogout = async () => {
     const params = JSON.parse(localStorage.getItem(AUTH_TOKEN) || '{}');
     localStorage.removeItem(AUTH_TOKEN);
-    window.location.href = `https://login.elixir-czech.org/oidc/endsession?id_token_hint=${params.id_token}&post_logout_redirect_uri=${HOST_URI}`;
+    window.location.href = `https://login.aai.lifescience-ri.eu/oidc/endsession?id_token_hint=${params.id_token}&post_logout_redirect_uri=${HOST_URI}`;
     setIsLoggedIn(LoginStatus.NOT_LOGGED_IN);
   };
 

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -58,7 +58,7 @@ const Layout = () => {
       setIsLoggedIn(LoginStatus.LOADING);
       try {
         const response = await axios.get(
-          'https://login.elixir-czech.org/oidc/userinfo',
+          'https://login.aai.lifescience-ri.eu/oidc/userinfo',
           {
             headers: {
               Authorization: `Bearer ${localParams?.access_token || ''}`


### PR DESCRIPTION
**IMPORTANT: Please create an issue before filing a pull request! Changes need to be discussed before proceeding. Please read the [contribution guidelines](CONTRIBUTING.md).**

**Details**

Update LSAAI URL. From `https://login.elixir-czech.org` to `https://login.aai.lifescience-ri.eu`

**Testing**

Rebuild in Rahti. Accessible here: https://elixir-krini-devel.2.rahtiapp.fi/login

<img width="1427" alt="Screenshot 2025-05-15 at 11 16 59" src="https://github.com/user-attachments/assets/e5cb84b0-8abf-4be6-83ce-e48837ff9092" />

## Summary by Sourcery

Update LSAAI OIDC endpoints to the new domain across login, logout, and userinfo requests

Enhancements:
- Replace login redirect URL to https://login.aai.lifescience-ri.eu
- Replace logout endpoint URL to https://login.aai.lifescience-ri.eu
- Update userinfo endpoint URL to https://login.aai.lifescience-ri.eu